### PR TITLE
feat(proxy): add scripts for managing SSH and redsocks

### DIFF
--- a/proxy/mon
+++ b/proxy/mon
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+while true; do
+    if ! pgrep -f "ssh -D 1337" > /dev/null; then
+        ssh -D 1337 -C -N user@remote-host &
+    fi
+
+    if ! pgrep -f "redsocks" > /dev/null; then
+        sudo systemctl start redsocks
+    fi
+
+    sleep 60
+done

--- a/proxy/start
+++ b/proxy/start
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# Set up SSH tunnel
+ssh -D 1337 -C -N hostinger_1 &
+
+# Set up redsocks
+sudo systemctl start redsocks
+
+# Create new chain if it doesn't exist
+sudo iptables -t nat -L REDSOCKS > /dev/null || sudo iptables -t nat -N REDSOCKS
+
+# Ignore reserved and local networks
+sudo iptables -t nat -A REDSOCKS -d 0.0.0.0/8 -j RETURN
+sudo iptables -t nat -A REDSOCKS -d 10.0.0.0/8 -j RETURN
+sudo iptables -t nat -A REDSOCKS -d 100.64.0.0/10 -j RETURN
+sudo iptables -t nat -A REDSOCKS -d 127.0.0.0/8 -j RETURN
+sudo iptables -t nat -A REDSOCKS -d 169.254.0.0/16 -j RETURN
+sudo iptables -t nat -A REDSOCKS -d 172.16.0.0/12 -j RETURN
+sudo iptables -t nat -A REDSOCKS -d 192.168.0.0/16 -j RETURN
+sudo iptables -t nat -A REDSOCKS -d 198.18.0.0/15 -j RETURN
+sudo iptables -t nat -A REDSOCKS -d 224.0.0.0/4 -j RETURN
+sudo iptables -t nat -A REDSOCKS -d 240.0.0.0/4 -j RETURN
+
+# Redirect traffic to redsocks
+sudo iptables -t nat -A REDSOCKS -p tcp -j REDIRECT --to-ports 1338
+
+# Apply the REDSOCKS chain to all traffic
+sudo iptables -t nat -A PREROUTING -p tcp -j REDSOCKS
+sudo iptables -t nat -A OUTPUT -p tcp -j REDSOCKS
+
+# Allow redsocks traffic
+sudo iptables -A INPUT -p tcp --dport 1338 -j ACCEPT

--- a/proxy/stop
+++ b/proxy/stop
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+sudo iptables -t nat -F REDSOCKS
+sudo iptables -t nat -X REDSOCKS
+sudo iptables -F INPUT
+sudo systemctl stop redsocks
+killall ssh


### PR DESCRIPTION
Implement scripts to start and stop SSH tunneling and redsocks. The 
`start` sets up the SSH tunnel and configures iptables to 
redirect traffic through redsocks. The `stop` script cleans up 
iptables rules and terminates the SSH process. Additionally, a 
monitoring script ensures that the SSH tunnel and redsocks are 
running continuously. These changes enhance network traffic 
management and improve connectivity reliability.