### PR TITLE
feat: add RPM installation and update scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/install_rpm/install_log.txt
+/install_rpm/installed_packages.txt
+temp_downloads
+/update 3rd party rpm/3rdpartyrpms.text
+/update 3rd party rpm/update_log.txt
+/update 3rd party rpm/update.log
+/update 3rd party rpm/valid_packages.txt

--- a/install_rpm/install_rpm.sh
+++ b/install_rpm/install_rpm.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Display usage instructions
+usage() {
+    echo "Usage: $0 <url-to-rpm-file> [--ignore-signature]"
+    exit 1
+}
+
+# Download the RPM file with retries using wget
+download_rpm() {
+    RPM_FILE=$(basename "$RPM_URL")
+
+    if [[ -f "$RPM_FILE" ]]; then
+        if rpm --quiet --checksig ./"$RPM_FILE"; then
+            echo "$RPM_FILE is valid. No need to download again."
+            return 0
+        else
+            echo "$RPM_FILE is corrupted. Removing it..."
+            rm -f "$RPM_FILE"
+        fi
+    fi
+
+    for attempt in {1..3}; do
+        echo "Downloading $RPM_FILE from $RPM_URL using wget..."
+        if wget -O "$RPM_FILE" "$RPM_URL"; then
+            return 0
+        fi
+        echo "Download failed. Attempt $attempt of 3..."
+        sleep 2
+    done
+
+    echo "Error downloading $RPM_URL after 3 attempts."
+    exit 1
+}
+
+# Install the RPM file using zypper
+install_rpm() {
+    echo "Installing $RPM_FILE using zypper..."
+    if [ "$IGNORE_SIGNATURE" == "true" ]; then
+        sudo zypper install --no-gpg-checks ./"$RPM_FILE" | tee -a install_log.txt
+    else
+        sudo zypper install ./"$RPM_FILE" | tee -a install_log.txt
+    fi
+}
+
+# Cleanup function to remove the RPM file
+cleanup() {
+    echo "Cleaning up..."
+    rm -f "$RPM_FILE"
+}
+
+# Main script execution
+if [ "$#" -lt 1 ]; then
+    usage
+fi
+
+IGNORE_SIGNATURE="false"
+[ "$2" == "--ignore-signature" ] && IGNORE_SIGNATURE="true"
+
+RPM_URL=$1
+
+# Log output to a file
+exec > >(tee -i install_log.txt)
+exec 2>&1
+
+# Download and install the RPM file
+download_rpm
+if ! rpm --quiet --checksig ./"$(basename "$RPM_URL")"; then
+    echo "Signature verification failed for $RPM_FILE."
+    if [ "$IGNORE_SIGNATURE" == "true" ]; then
+        echo "Ignoring signature and installing..."
+        install_rpm
+    else
+        echo "Aborting installation."
+        exit 1
+    fi
+else
+    install_rpm
+fi
+
+# Cleanup after installation
+cleanup
+
+echo "Installation of $RPM_FILE completed successfully!"

--- a/update 3rd party rpm/update
+++ b/update 3rd party rpm/update
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+set -euo pipefail
+
+LOGFILE="update.log"
+VALID_PACKAGES_FILE="valid_packages.txt"
+TEMP_DIR="./temp_downloads"  # Temporary directory for downloaded files
+
+# Create temp download directory if it doesn't exist
+mkdir -p "$TEMP_DIR"
+
+log_info() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') INFO: $1" | tee -a "$LOGFILE"
+}
+
+log_error() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') ERROR: $1" | tee -a "$LOGFILE" >&2
+}
+
+cleanup() {
+    log_info "Cleaning up temporary files..."
+    rm -rf "$TEMP_DIR/*"
+}
+
+# Set a trap to ensure cleanup happens on script exit
+trap cleanup EXIT
+
+fetch_latest_release_info() {
+    local repo="$1"
+    log_info "Fetching latest release info from https://api.github.com/repos/$repo/releases/latest"
+    curl -s "https://api.github.com/repos/$repo/releases/latest" | jq -r '.tag_name, .assets[] | .name + " " + .browser_download_url'
+}
+
+install_package() {
+    local package_path="$1"
+    local package_name="${package_path##*/}"
+
+    log_info "Installing $package_name..."
+    if sudo rpm -Uvh "$package_path"; then
+        log_info "Installation of $package_name completed successfully."
+    else
+        log_error "Installation of $package_name failed or is already installed."
+    fi
+}
+
+select_valid_asset() {
+    local assets=("$@")
+    local valid_asset=""
+
+    for asset in "${assets[@]}"; do
+        local asset_name=$(echo "$asset" | awk '{print $1}')
+        if [[ "$asset_name" == *".rpm" ]]; then
+            valid_asset="$asset"
+            log_info "Valid RPM asset found: $valid_asset"
+            break
+        fi
+    done
+
+    echo "$valid_asset"
+}
+
+update_package() {
+    local repo="$1"
+    local latest_release_info
+    latest_release_info=$(fetch_latest_release_info "$repo")
+
+    local latest_release_version=$(echo "$latest_release_info" | head -n 1)
+    log_info "Latest release: $latest_release_version"
+
+    # Collect all asset information
+    readarray -t assets < <(echo "$latest_release_info" | tail -n +2)
+
+    if [[ ${#assets[@]} -eq 0 ]]; then
+        log_error "No assets found for $repo"
+        return 1
+    fi
+
+    local valid_asset=$(select_valid_asset "${assets[@]}")
+
+    if [[ -z "$valid_asset" ]]; then
+        log_error "No valid RPM found for $repo"
+        return 1
+    fi
+
+    echo "$repo:$valid_asset" >> "$VALID_PACKAGES_FILE"
+
+    local asset_url=$(echo "$valid_asset" | awk '{print $2}')
+    local package_name="${valid_asset%% *}"
+    local package_path="$TEMP_DIR/$package_name"
+
+    log_info "Downloading $package_name from $asset_url"
+    curl -L -o "$package_path" "$asset_url"
+
+    install_package "$package_path"
+}
+
+update_all() {
+    log_info "Updating all packages..."
+
+    if [[ ! -f "$VALID_PACKAGES_FILE" ]]; then
+        log_error "$VALID_PACKAGES_FILE not found. No packages to update."
+        return 1
+    fi
+
+    while IFS= read -r line; do
+        local repo=$(echo "$line" | awk -F: '{print $1}')
+        local package=$(echo "$line" | awk -F: '{print $2}')
+
+        log_info "Processing $repo..."
+        install_package "$package"
+    done < "$VALID_PACKAGES_FILE"
+}
+
+# Main script logic
+if [[ $# -lt 1 ]]; then
+    log_error "No arguments provided. Usage: $0 {update|all} [repo]"
+    exit 1
+fi
+
+case "$1" in
+    update)
+        if [[ $# -ne 2 ]]; then
+            log_error "Repository not specified. Usage: $0 update [repo]"
+            exit 1
+        fi
+        update_package "$2"
+        ;;
+    all)
+        update_all
+        ;;
+    *)
+        log_error "Invalid option: $1. Usage: $0 {update|all} [repo]"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Implement scripts for downloading and installing RPM packages. The 
`install_rpm.sh` script handles downloading RPM files with retries, 
validating signatures, and installing them using `zypper`. The 
`update` script fetches the latest release information from GitHub 
repositories, downloads valid RPM assets, and installs them. Both 
scripts include logging and cleanup mechanisms to enhance usability 
and maintainability.