### PR TITLE
fix: quote variable in latest tar URL extraction

### DIFF
--- a/cromite_launcher/cromite_launcher.sh
+++ b/cromite_launcher/cromite_launcher.sh
@@ -13,7 +13,7 @@ update_cromite() {
     latest_release_info=$(curl -s $GITHUB_API_URL)
 
     # Extract the URL of the latest tarball (chrome-lin64.tar.gz) from the JSON response
-    LATEST_TAR_URL=$(echo $latest_release_info | jq -r '.assets[] | select(.name=="chrome-lin64.tar.gz") | .browser_download_url')
+    LATEST_TAR_URL=$(echo "$latest_release_info" | jq -r '.assets[] | select(.name=="chrome-lin64.tar.gz") | .browser_download_url')
 
     if [ -z "$LATEST_TAR_URL" ]; then
         echo "Failed to fetch the latest release URL. Continuing with the current version..."


### PR DESCRIPTION
Quote the variable in the latest tar URL extraction to ensure proper  handling of the JSON response. This change prevents potential issues  with whitespace or special characters in the response, improving  reliability when fetching the latest release URL.